### PR TITLE
Fix "existing email" bug in update

### DIFF
--- a/cst438_registration/src/main/java/com/cst438/controller/StudentController.java
+++ b/cst438_registration/src/main/java/com/cst438/controller/StudentController.java
@@ -21,6 +21,7 @@ public class StudentController {
     EnrollmentRepository enrollmentRepository;
 
     @GetMapping("/student")
+    @CrossOrigin
     public List<StudentDTO> listStudents() {
         List<StudentDTO> allStudents = new ArrayList<>();
         for(Student s : studentRepository.findAll()) {
@@ -31,6 +32,7 @@ public class StudentController {
     }
 
     @PostMapping("/student")
+    @CrossOrigin
     public int addStudent(@RequestBody StudentDTO s) {
         Student student = studentRepository.findByEmail(s.email());
         // Can successfully add a student record when the email is distinct
@@ -48,11 +50,12 @@ public class StudentController {
     }
 
     @PutMapping("/student/{id}")
+    @CrossOrigin
     public Student update(@PathVariable("id") Integer id, @RequestBody StudentDTO us) {
         Student student = studentRepository.findById(id).orElse(null);
         if(student != null) {
             Student existingEmail = studentRepository.findByEmail(us.email());
-            if(existingEmail == null) {
+            if(existingEmail == null || existingEmail.getStudent_id() == id) {
                 student.setName(us.name());
                 student.setEmail(us.email());
                 student.setStatusCode(us.statusCode());
@@ -69,6 +72,7 @@ public class StudentController {
 
 
     @DeleteMapping("/student/{id}")
+    @CrossOrigin
     public void delete(
             @PathVariable("id") Integer id,
             @RequestParam("FORCE")Optional<Boolean> FORCE) {

--- a/cst438_registration/src/test/java/com/cst438/JunitTestStudent.java
+++ b/cst438_registration/src/test/java/com/cst438/JunitTestStudent.java
@@ -64,6 +64,40 @@ public class JunitTestStudent {
 
     @Test
     @DirtiesContext
+    public void updateStudentExceptEmail() throws Exception {
+        MockHttpServletResponse response;
+
+        StudentDTO updateStudent = new StudentDTO(3,"Ryan", "trebold@csumb.edu", 0, null);
+
+        // Perform update
+        response = mvc.perform(
+                        MockMvcRequestBuilders
+                                .put("/student/3")
+                                .content(asJsonString(updateStudent))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse();
+
+        // Verify update
+        response = mvc.perform(
+                        MockMvcRequestBuilders
+                                .get("/student")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse();
+
+        StudentDTO[] student_list = fromJsonString(response.getContentAsString(), StudentDTO[].class);
+        boolean found = false;
+        for (StudentDTO s : student_list) {
+            if (s.name().equals(updateStudent.name()) && s.email().equals(updateStudent.email())) {
+                found = true;
+            }
+        }
+        assertTrue(found);
+    }
+
+    @Test
+    @DirtiesContext
     public void addStudent() throws Exception {
         MockHttpServletResponse response;
 


### PR DESCRIPTION
Before there used to be a logical bug where you were unable to change a student's info because it scanned through existing emails to verify that the email was unique. However, it counted the email for the current student we were changing.

So if we changed just the name we were unable to execute the change because it checked its own email and counted it as a duplicate.